### PR TITLE
Rework scan service class

### DIFF
--- a/src/Services/Scan.php
+++ b/src/Services/Scan.php
@@ -2,7 +2,6 @@
 
 namespace io3x1\FilamentTranslations\Services;
 
-use Illuminate\Support\Facades\Lang;
 use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -21,6 +20,13 @@ class Scan
      * @var array
      */
     private $scannedPaths;
+
+    /**
+     * Regex patterns to find translations.
+     */
+    protected $patternA;
+    protected $patternB;
+    protected $patternC;
 
     /**
      * Manager constructor.
@@ -59,7 +65,7 @@ class Scan
             '@choice'
         ];
 
-        $patternA =
+        $this->patternA =
             // See https://regex101.com/r/jS5fX0/4
             '[^\w]' . // Must not start with any alphanum or _
             '(?<!->)' . // Must not start with ->
@@ -75,7 +81,7 @@ class Scan
             "[\),]"  // Close parentheses or new parameter
         ;
 
-        $patternB =
+        $this->patternB =
             // See https://regex101.com/r/2EfItR/2
             '[^\w]' . // Must not start with any alphanum or _
             '(?<!->)' . // Must not start with ->
@@ -92,7 +98,7 @@ class Scan
             '[\)]'  // Close parentheses or new parameter
         ;
 
-        $patternC =
+        $this->patternC =
             // See https://regex101.com/r/VaPQ7A/2
             '[^\w]' . // Must not start with any alphanum or _
             '(?<!->)' . // Must not start with ->
@@ -116,24 +122,51 @@ class Scan
         // FIXME maybe we can count how many times one translation is used and eventually display it to the user
 
         /** @var SplFileInfo $file */
-        foreach ($this->disk->allFiles($this->scannedPaths->toArray()) as $file) {
+        foreach ($this->scannedPaths->toArray() as $path) {
+            $this->scanFilesRecursively($path, $trans, $__, $excludedPaths);
+        }
+
+        return [$trans->flatten()->unique(), $__->flatten()->unique()];
+    }
+
+    protected function scanFilesRecursively($directory, $trans, $__, $excludedPaths)
+    {
+        $files = $this->disk->files($directory);
+        $directories = $this->disk->directories($directory);
+
+        foreach ($files as $file) {
             $dir = dirname($file);
-            if(\Str::startsWith($dir,$excludedPaths)) {
+
+            if ($this->startsWithExcludedPath($dir, $excludedPaths)) {
                 continue;
             }
 
-            if (preg_match_all("/$patternA/siU", $file->getContents(), $matches)) {
+            if (preg_match_all("/$this->patternA/siU", $this->disk->get($file), $matches)) {
                 $trans->push($matches[2]);
             }
 
-            if (preg_match_all("/$patternB/siU", $file->getContents(), $matches)) {
+            if (preg_match_all("/$this->patternB/siU", $this->disk->get($file), $matches)) {
                 $__->push($matches[2]);
             }
 
-            if (preg_match_all("/$patternC/siU", $file->getContents(), $matches)) {
+            if (preg_match_all("/$this->patternC/siU", $this->disk->get($file), $matches)) {
                 $__->push($matches[2]);
             }
         }
-        return [$trans->flatten()->unique(), $__->flatten()->unique()];
+
+        foreach ($directories as $subdirectory) {
+            $this->scanFilesRecursively($subdirectory, $trans, $__, $excludedPaths);
+        }
+    }
+
+    protected function startsWithExcludedPath($path, $excludedPaths)
+    {
+        foreach ($excludedPaths as $excludedPath) {
+            if (strpos($path, $excludedPath) === 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
I noticed that Livewire is breaking with no output when the scanning action button is pressed. A bit of debugging took me to `$disk->allFiles()` Illuminate Filesystem method throwing with the current recursive setup! So I worked around it with this.